### PR TITLE
Фиксы и добавления к мехе

### DIFF
--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -757,6 +757,45 @@ HARDPOINT MODULES (and their ammo)
 	containername = "tank ammo crate"
 	group = "Tank Hardpoint Modules"
 
+/datum/supply_packs/mech_smartgun_ammo
+	name = "M56 Double-Barrel Smartgun Magazines (x4)"
+	contains = list(
+					/obj/item/ammo_magazine/walker/smartgun,
+					/obj/item/ammo_magazine/walker/smartgun,
+					/obj/item/ammo_magazine/walker/smartgun,
+					/obj/item/ammo_magazine/walker/smartgun
+					)
+	cost = RO_PRICE_CHEAP
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "tank ammo crate"
+	group = "Tank Hardpoint Modules"
+
+/datum/supply_packs/mech_machinegun_ammo
+	name = "M30 Machine Gun Magazines (x4)"
+	contains = list(
+					/obj/item/ammo_magazine/walker/hmg,
+					/obj/item/ammo_magazine/walker/hmg,
+					/obj/item/ammo_magazine/walker/hmg,
+					/obj/item/ammo_magazine/walker/hmg
+					)
+	cost = RO_PRICE_CHEAP
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "tank ammo crate"
+	group = "Tank Hardpoint Modules"
+
+/datum/supply_packs/mech_f40_ammo
+	name = "F40 Canisters (x2)"
+	contains = list(
+					/obj/item/ammo_magazine/walker/flamer,
+					/obj/item/ammo_magazine/walker/flamer,
+					/obj/item/ammo_magazine/walker/flamer,
+					/obj/item/ammo_magazine/walker/flamer
+					)
+	cost = RO_PRICE_CHEAP
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "tank ammo crate"
+	group = "Tank Hardpoint Modules"
+
 /datum/supply_packs/tank_slauncher_ammo
 	name = "M75 Smoke Deploy System Magazines (x3)"
 	contains = list(

--- a/code/datums/supplypacks.dm
+++ b/code/datums/supplypacks.dm
@@ -14,7 +14,7 @@
 #define RO_PRICE_VERY_PRICY		100
 #define RO_PRICE_MAX_PRICY		120
 
-var/list/all_supply_groups = list("Operations", "Weapons", "Tank Hardpoint Modules", "APC Hardpoint Modules", "Attachments", "Ammo", "Armor", "Clothing", "Medical", "Engineering", "Science", "Supplies")
+var/list/all_supply_groups = list("Operations", "Weapons", "Tank Hardpoint Modules", "APC Hardpoint Modules", "Walker Ammunition", "Attachments", "Ammo", "Armor", "Clothing", "Medical", "Engineering", "Science", "Supplies")
 
 /datum/supply_packs
 	var/name = null
@@ -757,45 +757,6 @@ HARDPOINT MODULES (and their ammo)
 	containername = "tank ammo crate"
 	group = "Tank Hardpoint Modules"
 
-/datum/supply_packs/mech_smartgun_ammo
-	name = "M56 Double-Barrel Smartgun Magazines (x4)"
-	contains = list(
-					/obj/item/ammo_magazine/walker/smartgun,
-					/obj/item/ammo_magazine/walker/smartgun,
-					/obj/item/ammo_magazine/walker/smartgun,
-					/obj/item/ammo_magazine/walker/smartgun
-					)
-	cost = RO_PRICE_CHEAP
-	containertype = /obj/structure/closet/crate/ammo
-	containername = "tank ammo crate"
-	group = "Tank Hardpoint Modules"
-
-/datum/supply_packs/mech_machinegun_ammo
-	name = "M30 Machine Gun Magazines (x4)"
-	contains = list(
-					/obj/item/ammo_magazine/walker/hmg,
-					/obj/item/ammo_magazine/walker/hmg,
-					/obj/item/ammo_magazine/walker/hmg,
-					/obj/item/ammo_magazine/walker/hmg
-					)
-	cost = RO_PRICE_CHEAP
-	containertype = /obj/structure/closet/crate/ammo
-	containername = "tank ammo crate"
-	group = "Tank Hardpoint Modules"
-
-/datum/supply_packs/mech_f40_ammo
-	name = "F40 Canisters (x2)"
-	contains = list(
-					/obj/item/ammo_magazine/walker/flamer,
-					/obj/item/ammo_magazine/walker/flamer,
-					/obj/item/ammo_magazine/walker/flamer,
-					/obj/item/ammo_magazine/walker/flamer
-					)
-	cost = RO_PRICE_CHEAP
-	containertype = /obj/structure/closet/crate/ammo
-	containername = "tank ammo crate"
-	group = "Tank Hardpoint Modules"
-
 /datum/supply_packs/tank_slauncher_ammo
 	name = "M75 Smoke Deploy System Magazines (x3)"
 	contains = list(
@@ -919,6 +880,51 @@ APC Hardpoint Modules (and their ammo)
 	containertype = /obj/structure/closet/crate/ammo
 	containername = "apc ammo crate"
 	group = "APC Hardpoint Modules"
+
+
+/*******************************************************************************
+Walker Ammo
+*******************************************************************************/
+
+
+/datum/supply_packs/mech_smartgun_ammo
+	name = "M56 Double-Barrel Smartgun Magazines (x4)"
+	contains = list(
+					/obj/item/ammo_magazine/walker/smartgun,
+					/obj/item/ammo_magazine/walker/smartgun,
+					/obj/item/ammo_magazine/walker/smartgun,
+					/obj/item/ammo_magazine/walker/smartgun
+					)
+	cost = RO_PRICE_NEAR_FREE
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "walker ammo crate"
+	group = "Walker Ammunition"
+
+/datum/supply_packs/mech_machinegun_ammo
+	name = "M30 Machine Gun Magazines (x4)"
+	contains = list(
+					/obj/item/ammo_magazine/walker/hmg,
+					/obj/item/ammo_magazine/walker/hmg,
+					/obj/item/ammo_magazine/walker/hmg,
+					/obj/item/ammo_magazine/walker/hmg
+					)
+	cost = RO_PRICE_VERY_CHEAP
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "walker ammo crate"
+	group = "Walker Ammunition"
+
+/datum/supply_packs/mech_f40_ammo
+	name = "F40 Canisters (x4)"
+	contains = list(
+					/obj/item/ammo_magazine/walker/flamer,
+					/obj/item/ammo_magazine/walker/flamer,
+					/obj/item/ammo_magazine/walker/flamer,
+					/obj/item/ammo_magazine/walker/flamer
+					)
+	cost = RO_PRICE_VERY_CHEAP
+	containertype = /obj/structure/closet/crate/ammo
+	containername = "walker ammo crate"
+	group = "Walker Ammunition"
 
 
 /*******************************************************************************

--- a/code/modules/vehicles/mechvendor.dm
+++ b/code/modules/vehicles/mechvendor.dm
@@ -4,10 +4,10 @@ obj/machinery/vehicle_vendor/mech_vendor_ui
 	icon = 'icons/obj/machines/vending.dmi'
 	icon_state = "engi"
 
-	vendor_role = list("Walker Pilot", "Tank Crewman") //everyone else, mind your business
+	vendor_role = list("Walker Pilot") //everyone else, mind your business
 
 
-	var/list/aval_tank_mod = list("weapon" = 2, "ammo" = 5, "misc" = 0)
+	var/list/aval_tank_mod = list("weapon" = 2, "ammo" = 7, "misc" = 0)
 
 	listed_products = list(
 							list("WEAPONS (choose 2)", null, null, "misc", null),
@@ -169,7 +169,7 @@ obj/machinery/vehicle_vendor/mech_vendor_ui
 				IT.add_fingerprint(usr)
 				H.update_action_buttons()
 			else
-				to_chat(H, "<span class='warning'>You already took something from this category.</span>")
+				to_chat(H, "<span class='warning'>Not enough points in this category remain.</span>")
 				return
 		src.add_fingerprint(usr)
 		ui_interact(usr) //updates the nanoUI window

--- a/code/modules/vehicles/walker.dm
+++ b/code/modules/vehicles/walker.dm
@@ -18,7 +18,7 @@
 	var/zoom = FALSE
 	var/zoom_size = 14
 
-	pixel_x = -16
+	pixel_x = -18
 
 	health = 400
 	maxhealth = 400
@@ -208,6 +208,7 @@
 		zoom_activate()
 	if(pilot.client)
 		pilot.client.mouse_pointer_icon = initial(pilot.client.mouse_pointer_icon)
+	pilot.unset_interaction()
 	pilot.loc = src.loc
 	pilot = null
 	update_icon()
@@ -878,8 +879,8 @@
 /obj/structure/walker_wreckage
 	name = "CW13 wreckage"
 	desc = "Remains of some unfortunate walker. Completely unrepairable."
-	icon = 'icons/obj/vehicles/Mecha.dmi'
-	icon_state = "mecha-broken"
+	icon = 'icons/obj/vehicles/mech-walker.dmi'
+	icon_state = "mech-damaged"
 	density = TRUE
 	anchored = TRUE
 	opacity = FALSE


### PR DESCRIPTION
- Добавлены боеприпасы к оружию мехи в карго
- Убрана возможность танкистам использовать вендор мехи
- Увеличено количество поинтов в вендоре мехи с 5 до 7
- Пофикшен спрайт сломанной мехи
- Пофикшен неправильно подвинутый спрайт мехи
- Пофикшена возможность стрельбы из оружия мехи после выхода из неё.